### PR TITLE
Add timestamps to measured values

### DIFF
--- a/software/src/communication.c
+++ b/software/src/communication.c
@@ -32,6 +32,9 @@
 CallbackValue_int32_t callback_value_current;
 CallbackValue_int32_t callback_value_voltage;
 CallbackValue_int32_t callback_value_power;
+CallbackValueTimeState callback_value_time_current;
+CallbackValueTimeState callback_value_time_voltage;
+CallbackValueTimeState callback_value_time_power;
 
 BootloaderHandleMessageResponse handle_message(const void *message, void *response) {
 	switch(tfp_get_fid_from_message(message)) {
@@ -48,6 +51,16 @@ BootloaderHandleMessageResponse handle_message(const void *message, void *respon
 		case FID_GET_CONFIGURATION: return get_configuration(message, response);
 		case FID_SET_CALIBRATION: return set_calibration(message);
 		case FID_GET_CALIBRATION: return get_calibration(message, response);
+		case FID_GET_CURRENT_TIME: return get_value_time(message, response, &ina226.current, &ina226.current_time);
+		case FID_SET_CURRENT_TIME_CALLBACK_CONFIGURATION: return set_value_time_callback_configuration(message, &callback_value_time_current);
+		case FID_GET_CURRENT_TIME_CALLBACK_CONFIGURATION: return get_value_time_callback_configuration(message, response, &callback_value_time_current);
+		case FID_GET_VOLTAGE_TIME: return get_value_time(message, response, &ina226.voltage, &ina226.voltage_time);
+		case FID_SET_VOLTAGE_TIME_CALLBACK_CONFIGURATION: return set_value_time_callback_configuration(message, &callback_value_time_voltage);
+		case FID_GET_VOLTAGE_TIME_CALLBACK_CONFIGURATION: return get_value_time_callback_configuration(message, response, &callback_value_time_voltage);
+		case FID_GET_POWER_TIME: return get_value_time(message, response, &ina226.power, &ina226.current_time);
+		case FID_SET_POWER_TIME_CALLBACK_CONFIGURATION: return set_value_time_callback_configuration(message, &callback_value_time_power);
+		case FID_GET_POWER_TIME_CALLBACK_CONFIGURATION: return get_value_time_callback_configuration(message, response, &callback_value_time_power);
+		case FID_GET_TIME: return get_time(message, response);
 		default: return HANDLE_MESSAGE_RESPONSE_NOT_SUPPORTED;
 	}
 }
@@ -103,6 +116,34 @@ BootloaderHandleMessageResponse get_calibration(const GetCalibration *data, GetC
 	return HANDLE_MESSAGE_RESPONSE_NEW_MESSAGE;
 }
 
+BootloaderHandleMessageResponse get_value_time(const GetValueTime *data, GetValueTime_Response *response, const int32_t *value, const uint32_t *time) {
+	response->header.length = sizeof(GetValueTime_Response);
+	response->value = *value;
+	response->time = *time;
+
+	return HANDLE_MESSAGE_RESPONSE_NEW_MESSAGE;
+}
+
+BootloaderHandleMessageResponse set_value_time_callback_configuration(const SetValueTimeCallbackConfiguration *data, CallbackValueTimeState *state) {
+	state->enabled = data->enable;
+
+	return HANDLE_MESSAGE_RESPONSE_EMPTY;
+}
+
+BootloaderHandleMessageResponse get_value_time_callback_configuration(const GetValueTimeCallbackConfiguration *data, GetValueTimeCallbackConfiguration_Response *response, CallbackValueTimeState *state) {
+	response->header.length = sizeof(GetValueTimeCallbackConfiguration_Response);
+	response->enable = state->enabled;
+
+	return HANDLE_MESSAGE_RESPONSE_NEW_MESSAGE;
+}
+
+BootloaderHandleMessageResponse get_time(const GetTime *data, GetTime_Response *response) {
+	response->header.length = sizeof(GetTime_Response);
+	response->time = system_timer_get_ms();
+
+	return HANDLE_MESSAGE_RESPONSE_NEW_MESSAGE;
+}
+
 bool handle_current_callback(void) {
 	return handle_callback_value_callback_int32_t(&callback_value_current, FID_CALLBACK_CURRENT);
 }
@@ -115,6 +156,42 @@ bool handle_power_callback(void) {
 	return handle_callback_value_callback_int32_t(&callback_value_power, FID_CALLBACK_POWER);
 }
 
+bool handle_value_time_callback(CallbackValueTimeState *state, const uint8_t fid, const int32_t *value, const uint32_t *time) {
+	if(!state->is_buffered) {
+		if(!state->enabled || state->last_time == *time) {
+			return false;
+		}
+
+		tfp_make_default_header(&state->cb.header, bootloader_get_uid(), sizeof(ValueTime_Callback), fid);
+		state->cb.value = *value;
+		state->cb.time = *time;
+
+		state->last_time = *time;
+	}
+
+	if(bootloader_spitfp_is_send_possible(&bootloader_status.st)) {
+		bootloader_spitfp_send_ack_and_message(&bootloader_status, (uint8_t*)&state->cb, sizeof(ValueTime_Callback));
+		state->is_buffered = false;
+		return true;
+	} else {
+		state->is_buffered = true;
+	}
+
+	return false;
+}
+
+bool handle_current_time_callback(void) {
+	return handle_value_time_callback(&callback_value_time_current, FID_CALLBACK_CURRENT_TIME, &ina226.current, &ina226.current_time);
+}
+
+bool handle_voltage_time_callback(void) {
+	return handle_value_time_callback(&callback_value_time_voltage, FID_CALLBACK_VOLTAGE_TIME, &ina226.voltage, &ina226.voltage_time);
+}
+
+bool handle_power_time_callback(void) {
+	return handle_value_time_callback(&callback_value_time_power, FID_CALLBACK_POWER_TIME, &ina226.power, &ina226.current_time);
+}
+
 void communication_tick(void) {
 	communication_callback_tick();
 }
@@ -123,6 +200,16 @@ void communication_init(void) {
 	callback_value_init_int32_t(&callback_value_current, ina226_get_current);
 	callback_value_init_int32_t(&callback_value_voltage, ina226_get_voltage);
 	callback_value_init_int32_t(&callback_value_power, ina226_get_power);
+
+	callback_value_time_current.is_buffered = false;
+	callback_value_time_current.enabled = false;
+	callback_value_time_current.last_time = 0;
+	callback_value_time_voltage.is_buffered = false;
+	callback_value_time_voltage.enabled = false;
+	callback_value_time_voltage.last_time = 0;
+	callback_value_time_power.is_buffered = false;
+	callback_value_time_power.enabled = false;
+	callback_value_time_power.last_time = 0;
 
 	communication_callback_init();
 }

--- a/software/src/communication.h
+++ b/software/src/communication.h
@@ -82,10 +82,23 @@ void communication_init(void);
 #define FID_GET_CONFIGURATION 14
 #define FID_SET_CALIBRATION 15
 #define FID_GET_CALIBRATION 16
+#define FID_GET_CURRENT_TIME 17
+#define FID_SET_CURRENT_TIME_CALLBACK_CONFIGURATION 18
+#define FID_GET_CURRENT_TIME_CALLBACK_CONFIGURATION 19
+#define FID_GET_VOLTAGE_TIME 21
+#define FID_SET_VOLTAGE_TIME_CALLBACK_CONFIGURATION 22
+#define FID_GET_VOLTAGE_TIME_CALLBACK_CONFIGURATION 23
+#define FID_GET_POWER_TIME 25
+#define FID_SET_POWER_TIME_CALLBACK_CONFIGURATION 26
+#define FID_GET_POWER_TIME_CALLBACK_CONFIGURATION 27
+#define FID_GET_TIME 29
 
 #define FID_CALLBACK_CURRENT 4
 #define FID_CALLBACK_VOLTAGE 8
 #define FID_CALLBACK_POWER 12
+#define FID_CALLBACK_CURRENT_TIME 20
+#define FID_CALLBACK_VOLTAGE_TIME 24
+#define FID_CALLBACK_POWER_TIME 28
 
 typedef struct {
 	TFPMessageHeader header;
@@ -125,24 +138,80 @@ typedef struct {
 	uint16_t current_divisor;
 } __attribute__((__packed__)) GetCalibration_Response;
 
+typedef struct {
+	TFPMessageHeader header;
+} __attribute__((__packed__)) GetValueTime;
+
+typedef struct {
+	TFPMessageHeader header;
+	int32_t value;
+	uint32_t time;
+} __attribute__((__packed__)) GetValueTime_Response;
+
+typedef struct {
+	TFPMessageHeader header;
+	bool enable;
+} __attribute__((__packed__)) SetValueTimeCallbackConfiguration;
+
+typedef struct {
+	TFPMessageHeader header;
+} __attribute__((__packed__)) GetValueTimeCallbackConfiguration;
+
+typedef struct {
+	TFPMessageHeader header;
+	bool enable;
+} __attribute__((__packed__)) GetValueTimeCallbackConfiguration_Response;
+
+typedef struct {
+	TFPMessageHeader header;
+	int32_t value;
+	uint32_t time;
+} __attribute__((__packed__)) ValueTime_Callback;
+
+typedef struct {
+	TFPMessageHeader header;
+} __attribute__((__packed__)) GetTime;
+
+typedef struct {
+	TFPMessageHeader header;
+	uint32_t time;
+} __attribute__((__packed__)) GetTime_Response;
+
+typedef struct {
+	bool is_buffered;
+	ValueTime_Callback cb;
+
+	bool enabled;
+	uint32_t last_time;
+} CallbackValueTimeState;
 
 // Function prototypes
 BootloaderHandleMessageResponse set_configuration(const SetConfiguration *data);
 BootloaderHandleMessageResponse get_configuration(const GetConfiguration *data, GetConfiguration_Response *response);
 BootloaderHandleMessageResponse set_calibration(const SetCalibration *data);
 BootloaderHandleMessageResponse get_calibration(const GetCalibration *data, GetCalibration_Response *response);
+BootloaderHandleMessageResponse get_value_time(const GetValueTime *data, GetValueTime_Response *response, const int32_t *value, const uint32_t *time);
+BootloaderHandleMessageResponse set_value_time_callback_configuration(const SetValueTimeCallbackConfiguration *data, CallbackValueTimeState *state);
+BootloaderHandleMessageResponse get_value_time_callback_configuration(const GetValueTimeCallbackConfiguration *data, GetValueTimeCallbackConfiguration_Response *response, CallbackValueTimeState *state);
+BootloaderHandleMessageResponse get_time(const GetTime *data, GetTime_Response *response);
 
 // Callbacks
 bool handle_current_callback(void);
 bool handle_voltage_callback(void);
 bool handle_power_callback(void);
+bool handle_current_time_callback(void);
+bool handle_voltage_time_callback(void);
+bool handle_power_time_callback(void);
 
 #define COMMUNICATION_CALLBACK_TICK_WAIT_MS 1
-#define COMMUNICATION_CALLBACK_HANDLER_NUM 3
+#define COMMUNICATION_CALLBACK_HANDLER_NUM 6
 #define COMMUNICATION_CALLBACK_LIST_INIT \
 	handle_current_callback, \
 	handle_voltage_callback, \
 	handle_power_callback, \
+	handle_current_time_callback, \
+	handle_voltage_time_callback, \
+	handle_power_time_callback, \
 
 
 #endif

--- a/software/src/configs/config.h
+++ b/software/src/configs/config.h
@@ -33,7 +33,7 @@
 
 #define FIRMWARE_VERSION_MAJOR 2
 #define FIRMWARE_VERSION_MINOR 0
-#define FIRMWARE_VERSION_REVISION 3
+#define FIRMWARE_VERSION_REVISION 4
 
 #include "config_custom_bootloader.h"
 

--- a/software/src/ina226.c
+++ b/software/src/ina226.c
@@ -157,6 +157,7 @@ void ina226_tick(void) {
 				switch(ina226.state) {
 					case INA226_STATE_READ_VOLTAGE: {
 						ina226.voltage = ((((buffer[0] << 8) | buffer[1]) * VOLTAGE_ADC_MV_MUL) / VOLTAGE_ADC_MV_DIV) * ina226.cal_v_multiplier / ina226.cal_v_divisor;
+						ina226.voltage_time = system_timer_get_ms();
 						ina226.state = INA226_STATE_READ_CURRENT;
 						//logd("voltage: %d\n\r", ina226.voltage);
 						break;
@@ -165,6 +166,7 @@ void ina226_tick(void) {
 					case INA226_STATE_READ_CURRENT: {
 						ina226.current = ((((int16_t)((buffer[0] << 8) | buffer[1])) * CURRENT_ADC_MA_MUL) / CURRENT_ADC_MA_DIV) * ina226.cal_c_multiplier / ina226.cal_c_divisor;
 						ina226.power = (ina226.voltage * ina226.current) / 1000;
+						ina226.current_time = system_timer_get_ms();
 						ina226.state = INA226_STATE_READ_MASK;
 						//logd("current: %d\n\r", ina226.current);
 						break;

--- a/software/src/ina226.h
+++ b/software/src/ina226.h
@@ -88,6 +88,8 @@ typedef struct {
 	int32_t voltage;
 	int32_t current;
 	int32_t power;
+	uint32_t voltage_time;
+	uint32_t current_time;
 	bool new_calibration;
 	bool new_configuration;
 	bool new_mask;


### PR DESCRIPTION
This PR extends the firmware to address two problems when using the bricklet in measurement setups in order to increase measurement accuracy, i.e. for use in scientific work[^1].
First, the current firmware reads the results from the INA226 when ever a new value is available, but the callback trigger runs fully asynchronous of this. This could lead to an unpredictable delay of the measured values. E.g. using a configuration of 588us conversion time for voltage and current and an averaging value of 4 will provide a new value from the INA226 every ~4.7 ms. If the callback triggers every 5 ms the measured value could be something between 0 and 4.7ms old already. In addition, as the time spans from the configuration and the time spans from the callback do not match, some values may be lost or send multiple times, which may is suboptimal when using the measured values for integration over time.
Further, when using many of these bricklets (>10) with a high temporal resolution connected to a stack of multiple master bricks, the transfer speed may is limited which leads to observable jittering of the time spans when measured values are received. This makes it inaccurate when time stamps are added only when receiving values.

To solve this a new callback is added, which is triggered directly when the INA226 has a new value instead of using a time based callback and, further, a timestamp is stored and transmitted for the measured values. The get_time function allows to read the bricklet time to synchronize.
Limitation: A timestamp is stored internally to detect value changes, therefore if the conversion/averaging times provide multiple values per millisecond, still only a single callback is triggered.

This PR is made as draft because currently the new functionality is only added for the power values. Before continuing work, you may have some feedback if you are interested in these features for the official firmware or if it is too special interest to be merged.
If this is interesting for you we are of course also open for feedback to the actual implementation. For testing we generated the bindings here: https://github.com/UniStuttgart-VISUS/generators/tree/power-time

[^1]: Müller et al. "Power Overwhelming: Quantifying the Energy Cost of Visualisation," https://doi.org/10.1109/BELIV57783.2022.00009